### PR TITLE
feat: Implement TUI for starting new feature branches

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -5,9 +5,6 @@ package cmd
 
 import (
 	"github.com/Orctatech-Engineering-Team/GitMate/internal/tui"
-	tea "github.com/charmbracelet/bubbletea"
-	"log"
-
 	"github.com/spf13/cobra"
 )
 
@@ -16,11 +13,11 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start a new feature branch workflow",
 	Long:  ` This command will start a new workflow.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		p := tea.NewProgram(tui.NewModel(tui.CmdStart)) // pass initial command
-		if err, _ := p.Run(); err != nil {
-			log.Fatal(err)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return tui.RunStartTUI("")
 		}
+		return tui.RunStartTUI(args[0])
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
@@ -35,6 +36,7 @@ require (
 	github.com/muesli/roff v0.1.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
@@ -37,6 +39,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -65,6 +69,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -74,7 +74,7 @@ func GitStatusPorcelain(dir string) ([]FileStatus, error) {
 // It returns a slice of FileStatus preserving Index/Worktree status and path(s).
 //
 // Format (per-line):
-// XY <path>          (for regular)
+// XY <path> (for regular)
 // XY <from> -> <to>  (for rename/copy)
 // We split the line into the 2-status chars then the rest after a single space.
 func ParsePorcelain(out string) []FileStatus {
@@ -177,7 +177,7 @@ func Fetch(dir string) error {
 	return nil
 }
 
-// Rebase runs `git rebase origin/main`
+// RebaseOntoMain Rebase runs `git rebase origin/main`
 func RebaseOntoMain(dir string) error {
 	ctx := context.Background()
 	_, err := RunCombined(ctx, dir, "rebase", "origin/main")
@@ -256,4 +256,15 @@ func RunGitWithOutput(ctx context.Context, args ...string) (<-chan string, <-cha
 	}()
 
 	return outCh, errCh
+}
+
+// IsDirty checks if there are any uncommitted changes in the repo.
+// Returns true if there are staged or unstaged changes.
+func IsDirty(dir string) (bool, error) {
+	ctx := context.Background()
+	out, err := RunCombined(ctx, dir, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) != "", nil
 }

--- a/internal/tui/common.go
+++ b/internal/tui/common.go
@@ -1,0 +1,38 @@
+package tui
+
+import (
+	"context"
+	"github.com/Orctatech-Engineering-Team/GitMate/internal/git"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// --- messages
+type gitLineMsg string
+type gitErrMsg error
+type gitDoneMsg struct{}
+
+// streamStep runs a git command, streams logs/errors into Update, then calls next if success
+func streamStep(p *tea.Program, cmd string, args []string, next func()) {
+	ctx := context.Background()
+	outCh, errCh := git.RunGitWithOutput(ctx, append([]string{cmd}, args...)...)
+
+	// forward stdout
+	go func() {
+		for line := range outCh {
+			p.Send(gitLineMsg(line))
+		}
+	}()
+
+	// forward stderr/errors
+	go func() {
+		for err := range errCh {
+			if err != nil {
+				p.Send(gitErrMsg(err))
+				return
+			}
+		}
+		if next != nil {
+			next()
+		}
+	}()
+}

--- a/internal/tui/start.go
+++ b/internal/tui/start.go
@@ -1,0 +1,276 @@
+/*
+Copyright © 2025 Bernard Katamanso <bernard@orctatech.com>
+*/
+package tui
+
+import (
+	"context"
+	"fmt"
+	"github.com/charmbracelet/bubbles/list"
+	"regexp"
+	"strings"
+
+	"github.com/Orctatech-Engineering-Team/GitMate/internal/git"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ---------------- Prompt Model ----------------
+
+type promptChoice string
+
+const (
+	choiceStash   promptChoice = "Stash changes"
+	choiceCommit  promptChoice = "Commit all changes"
+	choiceDiscard promptChoice = "Discard changes"
+	choiceQuit    promptChoice = "Quit"
+)
+
+type promptModel struct {
+	list   list.Model
+	done   bool
+	choice promptChoice
+}
+
+func NewPromptModel() promptModel {
+	items := []list.Item{
+		listItem(choiceStash),
+		listItem(choiceCommit),
+		listItem(choiceDiscard),
+		listItem(choiceQuit),
+	}
+	l := list.New(items, list.NewDefaultDelegate(), 30, 10)
+	l.Title = "Uncommitted changes detected. What do you want to do?"
+	return promptModel{list: l}
+}
+
+func (m promptModel) Init() tea.Cmd { return nil }
+
+func (m promptModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			i, ok := m.list.SelectedItem().(listItem)
+			if ok {
+				m.choice = promptChoice(i)
+				m.done = true
+				return m, tea.Quit
+			}
+		case "q", "ctrl+c":
+			m.choice = choiceQuit
+			m.done = true
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m promptModel) View() string {
+	if m.done {
+		return fmt.Sprintf("Selected: %s\n", m.choice)
+	}
+	return m.list.View()
+}
+
+type listItem string
+
+func (i listItem) FilterValue() string { return string(i) }
+
+// ---------------- Branch Name Input Model ----------------
+
+type branchInputModel struct {
+	textInput textinput.Model
+	done      bool
+	branch    string
+}
+
+func NewBranchInputModel() branchInputModel {
+	ti := textinput.New()
+	ti.Placeholder = "Enter feature branch name..."
+	ti.Focus()
+	ti.CharLimit = 64
+	ti.Width = 30
+	return branchInputModel{textInput: ti}
+}
+
+func (m branchInputModel) Init() tea.Cmd { return textinput.Blink }
+
+func (m branchInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			m.done = true
+			m.branch = m.textInput.Value()
+			return m, tea.Quit
+		case "ctrl+c":
+			m.done = true
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+func (m branchInputModel) View() string {
+	return fmt.Sprintf(
+		"Feature branch name:\n%s\n\n(press enter to continue, ctrl+c to quit)",
+		m.textInput.View(),
+	)
+}
+
+// ---------------- Start Model ----------------
+
+type startModel struct {
+	spinner spinner.Model
+	logs    []string
+	err     error
+	done    bool
+	branch  string
+}
+
+func NewStartModel(branch string) startModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	return startModel{
+		spinner: s,
+		branch:  branch,
+	}
+}
+
+func (m startModel) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+func (m startModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "q" || msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+	case spinner.TickMsg:
+		if !m.done {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+	case gitLineMsg:
+		m.logs = append(m.logs, string(msg))
+	case gitErrMsg:
+		m.err = msg
+		m.done = true
+		return m, tea.Quit
+	case gitDoneMsg:
+		m.done = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m startModel) View() string {
+	s := fmt.Sprintf("GitMate: Starting new feature branch '%s'\n\n", m.branch)
+	if m.err != nil {
+		s += "Error: " + m.err.Error() + "\n"
+	} else if m.done {
+		s += fmt.Sprintf("✅ Branch feature/%s created and checked out.\n\n", m.branch)
+	} else {
+		s += m.spinner.View() + " Running git commands...\n\n"
+	}
+	start := 0
+	if len(m.logs) > 10 {
+		start = len(m.logs) - 10
+	}
+	for _, line := range m.logs[start:] {
+		s += line + "\n"
+	}
+	if m.done {
+		s += "\n(press q to quit)"
+	}
+	return s
+}
+
+// ---------------- Helpers ----------------
+
+func sanitizeBranchName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	re := regexp.MustCompile(`[^a-z0-9._-]+`)
+	return re.ReplaceAllString(name, "-")
+}
+
+// ---------------- Orchestration ----------------
+
+// runStart orchestrates checkout main → pull → create feature branch with live logs
+func runStart(p *tea.Program, branch string) {
+	streamStep(p, "checkout", []string{"main"}, func() {
+		streamStep(p, "pull", []string{"origin", "main"}, func() {
+			safe := sanitizeBranchName(branch)
+			streamStep(p, "checkout", []string{"-b", "feature/" + safe}, func() {
+				p.Send(gitDoneMsg{})
+			})
+		})
+	})
+}
+
+// ---------------- Public Entry ----------------
+
+func RunStartTUI(featureName string) error {
+	// 1. Prompt for branch name if none provided
+	if featureName == "" {
+		tiProgram := tea.NewProgram(NewBranchInputModel())
+		final, err := tiProgram.Run()
+		if err != nil {
+			return err
+		}
+		if m, ok := final.(branchInputModel); ok {
+			featureName = m.branch
+		}
+		if featureName == "" {
+			return fmt.Errorf("no branch name provided")
+		}
+	}
+
+	// 2. Check if repo is dirty
+	dirty, err := git.IsDirty(".")
+	if err != nil {
+		return err
+	}
+	if dirty {
+		// Run prompt for stash/commit/discard
+		pm := tea.NewProgram(NewPromptModel())
+		go runStart(pm, featureName)
+		final, err := pm.Run()
+		if err != nil {
+			return err
+		}
+		if p, ok := final.(promptModel); ok {
+			switch p.choice {
+			case choiceStash:
+				_, err = git.RunCombined(context.Background(), ".", "stash", "push", "-u")
+			case choiceCommit:
+				_, err = git.RunCombined(context.Background(), ".", "add", "-A")
+				if err == nil {
+					// Open Git editor for commit message
+					_, err = git.RunCombined(context.Background(), ".", "commit")
+				}
+			case choiceDiscard:
+				_, err = git.RunCombined(context.Background(), ".", "reset", "--hard")
+			case choiceQuit:
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// 3. Run main start model with live logs
+	p := tea.NewProgram(NewStartModel(featureName))
+	runStart(p, featureName)
+	_, err = p.Run()
+	return err
+}

--- a/internal/tui/sync.go
+++ b/internal/tui/sync.go
@@ -4,9 +4,6 @@ Copyright © 2025 Bernard Katamanso
 package tui
 
 import (
-	"context"
-
-	"github.com/Orctatech-Engineering-Team/GitMate/internal/git"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -17,11 +14,6 @@ type syncModel struct {
 	err     error
 	done    bool
 }
-
-// --- messages
-type gitLineMsg string
-type gitErrMsg error
-type gitDoneMsg struct{}
 
 // --- constructor
 func NewSyncModel() syncModel {
@@ -106,32 +98,6 @@ func runSync(p *tea.Program) {
 			p.Send(gitDoneMsg{})
 		})
 	})
-}
-
-// streamStep runs a git command, streams logs/errors into Update, then calls next if success
-func streamStep(p *tea.Program, cmd string, args []string, next func()) {
-	ctx := context.Background()
-	outCh, errCh := git.RunGitWithOutput(ctx, append([]string{cmd}, args...)...)
-
-	// forward stdout
-	go func() {
-		for line := range outCh {
-			p.Send(gitLineMsg(line))
-		}
-	}()
-
-	// forward stderr/errors
-	go func() {
-		for err := range errCh {
-			if err != nil {
-				p.Send(gitErrMsg(err))
-				return
-			}
-		}
-		if next != nil {
-			next()
-		}
-	}()
 }
 
 // --- Entry point for this TUI


### PR DESCRIPTION
This pull request refactors the feature branch workflow for the `start` command, improves modularity in the TUI (terminal UI) code, and adds new functionality for handling uncommitted changes. The changes modernize the workflow orchestration, introduce a user-friendly prompt for branch creation, and ensure better separation of concerns in the codebase.

**Feature Branch Workflow & TUI Improvements:**

* Refactored the `start` command in `cmd/start.go` to use a new TUI entrypoint (`RunStartTUI`), which prompts for a branch name if not provided and handles user interaction for uncommitted changes. The command now returns errors instead of using `log.Fatal`, improving error handling.
* Added a comprehensive new TUI workflow in `internal/tui/start.go`, including:
  - A prompt for the branch name,
  - A user choice menu for handling dirty working trees (stash, commit, discard, or quit),
  - Live streaming of git command logs,
  - Branch name sanitization,
  - Orchestration for checking out main, pulling, and creating the feature branch.
* Modularized the TUI's git command streaming logic into a reusable function in `internal/tui/common.go`, which streams git output and errors to the UI.
* Removed duplicated message types and streaming logic from `internal/tui/sync.go`, now shared via the new common module. [[1]](diffhunk://#diff-8d6fb133d38afad98309aa46afdf67857c5176fc3947bc50510f906bcb60590eL21-L25) [[2]](diffhunk://#diff-8d6fb133d38afad98309aa46afdf67857c5176fc3947bc50510f906bcb60590eL111-L136)

**Git Utilities:**

* Added `IsDirty` to `internal/git/git.go`, a utility to check for uncommitted changes in the repo, used to trigger user prompts before branch creation.
* Renamed the rebase helper for clarity (`RebaseOntoMain`) in `internal/git/git.go`.

**Dependency Updates:**

* Added new dependencies to `go.mod` for clipboard and fuzzy search support, likely for future TUI enhancements. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R13) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R39)